### PR TITLE
Let tox use salt2016 until the pip packages in pypi are sane again

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ envlist = py27,lint
 [base]
 deps =
     ipaddress
-    salt
+    salt<2017.0.0
 
 [testenv:py27]
 basepython = python2.7
@@ -28,7 +28,6 @@ deps =
     configobj
     boto
     codecov
-    pytest-cov
 
 [testenv:lint]
 basepython = python3


### PR DESCRIPTION
Signed-off-by: Joshua Schmid <jschmid@suse.de>

Fixes #


Description:


-----------------

[Please find more information on how to run integration tests here](https://github.com/SUSE/DeepSea/wiki/Integration-tests)
